### PR TITLE
RN 69 (Expo SDK 46): Bump kotlinVersion to 1.6.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-Midnight_kotlinVersion=1.3.50
+Midnight_kotlinVersion=1.6.0
 Midnight_compileSdkVersion=29
 Midnight_buildToolsVersion=29.0.2
 Midnight_targetSdkVersion=29


### PR DESCRIPTION
From Expo SDK 46 on, the `kotlinVersion` must be bumped to `1.6.0` in order to work with RN >69.